### PR TITLE
feat: 회원가입폼 누락된부분 마무리(SCENTLY-101)

### DIFF
--- a/src/api/signup/signup.ts
+++ b/src/api/signup/signup.ts
@@ -4,6 +4,7 @@ import ky from "ky";
 type SignupProps = {
   password_confirm: string;
   phone_number: string;
+  birth_date: string;
   password: string;
   nickname: string;
   gender: string;
@@ -14,23 +15,26 @@ type SignupProps = {
 const signup = async ({
   password_confirm,
   phone_number,
+  birth_date,
   password,
   nickname,
   gender,
   email,
   name,
 }: SignupProps) => {
+  const formData = new FormData();
+  formData.append("password_confirm", password_confirm);
+  formData.append("phone_number", phone_number);
+  formData.append("birth_date", birth_date);
+  formData.append("password", password);
+  formData.append("nickname", nickname);
+  formData.append("gender", gender);
+  formData.append("email", email);
+  formData.append("name", name);
+
   const response = await ky
     .post(`${API_BASE_URL}${API_URLS.SIGN_UP}`, {
-      json: {
-        password_confirm,
-        phone_number,
-        password,
-        nickname,
-        gender,
-        email,
-        name,
-      },
+      body: formData,
     })
     .json();
 

--- a/src/app/login/@modal/(.)register/actions.ts
+++ b/src/app/login/@modal/(.)register/actions.ts
@@ -16,8 +16,21 @@ export type FormState = {
 
 export async function register(
   prevState: FormState,
-  data: z.infer<typeof registerSchema>,
+  formData: FormData,
 ): Promise<FormState> {
+  const data = {
+    isNicknameChecked: formData.get("isNicknameChecked") === "true",
+    verificationCode: formData.get("verificationCode") as string,
+    isEmailVerified: formData.get("isEmailVerified") === "true",
+    passwordConfirm: formData.get("passwordConfirm") as string,
+    phoneNumber: formData.get("phoneNumber") as string,
+    birthDate: formData.get("birthDate") as string,
+    nickname: formData.get("nickname") as string,
+    password: formData.get("password") as string,
+    gender: formData.get("gender") as string,
+    email: formData.get("email") as string,
+    name: formData.get("name") as string,
+  };
   const validatedFields = registerSchema.safeParse(data);
 
   if (!validatedFields.success) {
@@ -33,6 +46,7 @@ export async function register(
     await signupApi({
       password_confirm: validatedFields.data.passwordConfirm,
       phone_number: validatedFields.data.phoneNumber,
+      birth_date: validatedFields.data.birthDate,
       password: validatedFields.data.password,
       nickname: validatedFields.data.nickname,
       gender: validatedFields.data.gender,
@@ -45,8 +59,11 @@ export async function register(
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
 
+      const firstError = Object.values(errorResponse)[0] as string[];
+      const errorMessage = firstError[0] || "서버 에러가 발생했습니다.";
+
       return {
-        message: errorResponse.detail,
+        message: errorMessage,
         success: false,
       };
     }
@@ -70,9 +87,10 @@ export async function checkEmailVerificationCode(
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
+      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
 
       return {
-        message: errorResponse.detail,
+        message: errorMessage,
         success: false,
       };
     }
@@ -93,9 +111,10 @@ export async function sendEmailVerificationCode(email: string): Promise<{
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
+      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
 
       return {
-        message: errorResponse.detail,
+        message: errorMessage,
         success: false,
       };
     }
@@ -120,9 +139,10 @@ export async function checkNickname(nickname: string): Promise<{
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
+      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
 
       return {
-        message: errorResponse.detail,
+        message: errorMessage,
         success: false,
       };
     }

--- a/src/app/login/@modal/(.)register/actions.ts
+++ b/src/app/login/@modal/(.)register/actions.ts
@@ -59,8 +59,10 @@ export async function register(
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
 
-      const firstError = Object.values(errorResponse)[0] as string[];
-      const errorMessage = firstError[0] || "서버 에러가 발생했습니다.";
+      const errorValues = Object.values(errorResponse);
+      const errorMessage =
+        (Array.isArray(errorValues[0]) && errorValues[0][0]) ||
+        "서버 에러가 발생했습니다.";
 
       return {
         message: errorMessage,
@@ -87,7 +89,10 @@ export async function checkEmailVerificationCode(
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
-      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
+      const errorValues = Object.values(errorResponse);
+      const errorMessage =
+        (Array.isArray(errorValues[0]) && errorValues[0][0]) ||
+        "서버 에러가 발생했습니다.";
 
       return {
         message: errorMessage,
@@ -111,7 +116,10 @@ export async function sendEmailVerificationCode(email: string): Promise<{
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
-      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
+      const errorValues = Object.values(errorResponse);
+      const errorMessage =
+        (Array.isArray(errorValues[0]) && errorValues[0][0]) ||
+        "서버 에러가 발생했습니다.";
 
       return {
         message: errorMessage,
@@ -139,7 +147,7 @@ export async function checkNickname(nickname: string): Promise<{
   } catch (error) {
     if (error instanceof HTTPError) {
       const errorResponse = await error.response.json();
-      const errorMessage = errorResponse.detail || "서버 에러가 발생했습니다.";
+      const errorMessage = errorResponse.message || "서버 에러가 발생했습니다.";
 
       return {
         message: errorMessage,

--- a/src/app/login/@modal/(.)register/page.tsx
+++ b/src/app/login/@modal/(.)register/page.tsx
@@ -56,13 +56,18 @@ export default function RegisterModal() {
       return;
     }
 
-    if (!state.success && state.message) {
-      // 서버 에러 메시지 표시
-      alert(state.message);
-    }
-
     if (state.errors) {
+      Object.entries(state.errors).forEach(([key, value]) => {
+        if (value) {
+          form.setError(key as keyof RegisterSchema, {
+            message: value[0],
+            type: "server",
+          });
+        }
+      });
+    } else if (!state.success && state.message) {
       // TODO: 여기도 모달로 처리할지 확인
+      // 서버 에러 메시지 표시
       alert(state.message);
     }
   }, [state, router, form]);

--- a/src/app/login/@modal/(.)register/page.tsx
+++ b/src/app/login/@modal/(.)register/page.tsx
@@ -9,10 +9,11 @@ import NicknameSection from "@components/feature/register/NicknameSection";
 import PasswordSection from "@components/feature/register/PasswordSection";
 import GenderSection from "@components/feature/register/GenderSection";
 import EmailSection from "@components/feature/register/EmailSection";
+import PhoneSection from "@components/feature/register/PhoneSection";
 import NameSection from "@components/feature/register/NameSection";
 import { register } from "@app/login/@modal/(.)register/actions";
+import { useActionState, useTransition, useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useActionState, useEffect } from "react";
 import Dialog from "@components/common/Dialog";
 import Modal from "@components/common/Modal";
 import { useRouter } from "next/navigation";
@@ -27,9 +28,11 @@ export default function RegisterModal() {
     success: false,
     message: "",
   });
+  const [isPending, startTransition] = useTransition();
 
   const form = useForm<RegisterSchema>({
     defaultValues: {
+      isNicknameChecked: false,
       isEmailVerified: false,
       verificationCode: "",
       passwordConfirm: "",
@@ -42,6 +45,7 @@ export default function RegisterModal() {
       name: "",
     },
     resolver: zodResolver(registerSchema),
+    mode: "onChange",
   });
 
   useEffect(() => {
@@ -52,17 +56,16 @@ export default function RegisterModal() {
       return;
     }
 
-    if (state.errors) {
-      Object.entries(state.errors).forEach(([key, value]) => {
-        if (value) {
-          form.setError(key as keyof RegisterSchema, {
-            message: value[0],
-            type: "server",
-          });
-        }
-      });
+    if (!state.success && state.message) {
+      // 서버 에러 메시지 표시
+      alert(state.message);
     }
-  }, [state.success, router, state.message, form, state.errors]);
+
+    if (state.errors) {
+      // TODO: 여기도 모달로 처리할지 확인
+      alert(state.message);
+    }
+  }, [state, router, form]);
 
   return (
     <Modal
@@ -80,17 +83,29 @@ export default function RegisterModal() {
       >
         <div className="text-body-1 mt-8">회원가입</div>
         <form
+          onSubmit={form.handleSubmit((data) => {
+            const formData = new FormData();
+            Object.entries(data).forEach(([key, value]) => {
+              formData.append(key, value.toString());
+            });
+            startTransition(() => formAction(formData));
+          })}
           className="mt-6 flex h-[400px] flex-col gap-10 overflow-y-scroll"
-          onSubmit={form.handleSubmit(formAction)}
         >
           <NameSection form={form} />
           <NicknameSection form={form} />
           <BirthDateSection form={form} />
           <GenderSection form={form} />
           <EmailSection form={form} />
+          <PhoneSection form={form} />
           <PasswordSection form={form} />
-          <Button className="w-full shrink-0" type="submit" size={"2xl"}>
-            가입하기
+          <Button
+            className="w-full shrink-0"
+            disabled={isPending}
+            type="submit"
+            size={"2xl"}
+          >
+            {isPending ? "가입 중..." : "가입하기"}
           </Button>
         </form>
       </Dialog>

--- a/src/app/login/@modal/(.)register/schema.ts
+++ b/src/app/login/@modal/(.)register/schema.ts
@@ -2,101 +2,49 @@ import { z } from "zod";
 
 export const registerSchema = z
   .object({
+    phoneNumber: z
+      .string()
+      .min(1, { message: "전화번호를 입력해주세요." })
+      .refine((val) => val.length === 11, {
+        message: "전화번호는 11자리로 입력해주세요.",
+      }),
+    birthDate: z
+      .string()
+      .min(1, { message: "생년월일을 입력해주세요." })
+      .refine((val) => val.length === 8, {
+        message: "생년월일은 8자리로 입력해주세요.",
+      }),
+    nickname: z
+      .string()
+      .min(1, { message: "닉네임을 입력해주세요." })
+      .max(10, { message: "닉네임은 10자 이하로 입력해주세요." }),
+    isNicknameChecked: z.boolean().refine((val) => val === true, {
+      message: "닉네임 중복 확인을 해주세요.",
+    }),
+    isEmailVerified: z.boolean().refine((val) => val === true, {
+      message: "이메일 인증을 완료해주세요.",
+    }),
+    email: z
+      .email({ message: "올바른 이메일 형식이 아닙니다." })
+      .min(1, { message: "이메일을 입력해주세요." }),
+    passwordConfirm: z
+      .string()
+      .min(1, { message: "비밀번호 확인을 입력해주세요." }),
+    verificationCode: z
+      .string()
+      .min(1, { message: "인증 코드를 입력해주세요." }),
+    password: z.string().min(1, { message: "비밀번호를 입력해주세요." }),
+    name: z.string().min(1, { message: "이름을 입력해주세요." }),
     gender: z.enum(["MALE", "FEMALE"]),
-    verificationCode: z.string(),
-    isEmailVerified: z.boolean(),
-    passwordConfirm: z.string(),
-    phoneNumber: z.string(),
-    birthDate: z.string(),
-    nickname: z.string(),
-    password: z.string(),
-    email: z.string(),
-    name: z.string(),
   })
   .superRefine((data, ctx) => {
-    if (data.name.trim().length === 0) {
+    if (data.password !== data.passwordConfirm) {
       ctx.addIssue({
-        message: "이름을 입력해주세요.",
-        code: "custom",
-        path: ["name"],
-      });
-    }
-    if (data.nickname.trim().length === 0) {
-      ctx.addIssue({
-        message: "닉네임을 입력해주세요.",
-        path: ["nickname"],
-        code: "custom",
-      });
-    }
-    if (data.nickname.trim().length > 10) {
-      ctx.addIssue({
-        message: "닉네임은 10자 이하로 입력해주세요.",
-        path: ["nickname"],
-        code: "custom",
-      });
-    }
-    if (data.birthDate.trim().length === 0) {
-      ctx.addIssue({
-        message: "생년월일을 입력해주세요.",
-        path: ["birthDate"],
-        code: "custom",
-      });
-    }
-    if (data.birthDate.trim().length !== 8) {
-      ctx.addIssue({
-        message: "생년월일은 8자리로 입력해주세요.",
-        path: ["birthDate"],
-        code: "custom",
-      });
-    }
-    if (data.email.trim().length === 0) {
-      ctx.addIssue({
-        message: "이메일을 입력해주세요.",
-        path: ["email"],
-        code: "custom",
-      });
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
-      ctx.addIssue({
-        message: "올바른 이메일 형식이 아닙니다",
-        path: ["email"],
-        code: "custom",
-      });
-    }
-    if (data.password.length === 0) {
-      ctx.addIssue({
-        message: "비밀번호를 입력해주세요",
-        path: ["password"],
-        code: "custom",
-      });
-    }
-    if (data.passwordConfirm.length === 0) {
-      ctx.addIssue({
-        message: "비밀번호 확인을 입력해주세요",
-        path: ["passwordConfirm"],
-        code: "custom",
-      });
-    } else if (data.password !== data.passwordConfirm) {
-      ctx.addIssue({
-        message: "비밀번호가 일치하지 않습니다",
+        message: "비밀번호가 일치하지 않습니다.",
         path: ["passwordConfirm"],
         code: "custom",
       });
     }
-    if (data.verificationCode.trim().length === 0) {
-      ctx.addIssue({
-        path: ["verificationCode"],
-        message: "인증 코드를 입력해주세요.",
-        code: "custom",
-      });
-    }
-    if (data.isEmailVerified !== true) {
-      ctx.addIssue({
-        message: "이메일 인증을 완료해주세요.",
-        path: ["verificationCode"],
-        code: "custom",
-      });
-    }
-    // TODO: 전화번호 인증 추가
   });
 
 export type RegisterSchema = z.infer<typeof registerSchema>;

--- a/src/components/feature/register/BirthDateSection.tsx
+++ b/src/components/feature/register/BirthDateSection.tsx
@@ -15,7 +15,10 @@ const BirthDateSection = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-body-2 text-text-primary">생년월일</div>
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>생년월일</span>
+        <span className="text-system-error">*</span>
+      </div>
       <Input
         placeholder="8자리 입력해주세요 (ex. 20001004)"
         className="h-[48px] w-full"

--- a/src/components/feature/register/EmailSection.tsx
+++ b/src/components/feature/register/EmailSection.tsx
@@ -57,18 +57,37 @@ const EmailSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
     });
   };
 
+  let isEmailValid: undefined | boolean;
+  if (errors.email) {
+    isEmailValid = false;
+  } else if (isEmailVerified) {
+    isEmailValid = true;
+  }
+
+  let isVerificationCodeValid: undefined | boolean;
+  if (errors.verificationCode) {
+    isVerificationCodeValid = false;
+  } else if (isEmailVerified) {
+    isVerificationCodeValid = true;
+  }
+
   return (
     <div className="flex flex-col gap-4">
-      <div className="text-body-2 text-text-primary">이메일</div>
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>이메일</span>
+        <span className="text-system-error">*</span>
+      </div>
       <div className="flex flex-col gap-7">
         <div className="flex gap-3">
           <Input
-            validMessage={isEmailVerified ? "인증 완료" : undefined}
-            isValid={errors.email ? false : undefined}
+            validMessage={
+              isEmailVerified ? "인증이 완료되었습니다." : undefined
+            }
             errorMessage={errors.email?.message}
             className="h-[48px] w-[356px]"
             placeholder="이메일을 입력해주세요."
             disabled={isEmailVerified}
+            isValid={isEmailValid}
             type="email"
             {...register("email")}
           />
@@ -84,10 +103,12 @@ const EmailSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
         </div>
         <div className="flex gap-3">
           <Input
-            isValid={errors.verificationCode ? false : undefined}
-            validMessage={isEmailVerified ? "인증 완료" : undefined}
+            validMessage={
+              isEmailVerified ? "인증이 완료되었습니다." : undefined
+            }
             errorMessage={errors.verificationCode?.message}
             disabled={!isVerifyCodeSent || isEmailVerified}
+            isValid={isVerificationCodeValid}
             className="h-[48px] w-[356px]"
             placeholder="전송된 코드를 입력해주세요."
             type="text"

--- a/src/components/feature/register/GenderSection.tsx
+++ b/src/components/feature/register/GenderSection.tsx
@@ -13,7 +13,10 @@ const GenderSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-body-2 text-text-primary">성별</div>
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>성별</span>
+        <span className="text-system-error">*</span>
+      </div>
       <Controller
         render={({ field: { onChange, value } }) => (
           <div className="flex gap-2">

--- a/src/components/feature/register/NameSection.tsx
+++ b/src/components/feature/register/NameSection.tsx
@@ -11,7 +11,10 @@ const NameSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-body-2 text-text-primary">이름</div>
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>이름</span>
+        <span className="text-system-error">*</span>
+      </div>
       <Input
         className="h-[48px] w-full"
         placeholder="이름을 입력해주세요."

--- a/src/components/feature/register/NicknameSection.tsx
+++ b/src/components/feature/register/NicknameSection.tsx
@@ -1,6 +1,6 @@
 import { RegisterSchema } from "@app/login/@modal/(.)register/schema";
 import { checkNickname } from "@app/login/@modal/(.)register/actions";
-import React, { useTransition, useEffect, useState } from "react";
+import React, { useTransition, useEffect } from "react";
 import { UseFormReturn } from "react-hook-form";
 import Input from "@components/ui/input/Input";
 import Button from "@components/ui/Button";
@@ -12,11 +12,14 @@ const NicknameSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
     getValues,
     register,
     setError,
+    setValue,
     watch,
   } = form;
 
   const [isPending, startTransition] = useTransition();
-  const [isNicknameChecked, setIsNicknameChecked] = useState(false);
+
+  const nicknameValue = watch("nickname");
+  const isNicknameChecked = watch("isNicknameChecked");
 
   const handleCheckNickname = () => {
     const nickname = getValues("nickname");
@@ -26,23 +29,34 @@ const NicknameSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
 
       if (result.success) {
         clearErrors("nickname");
-        setIsNicknameChecked(true);
+        setValue("isNicknameChecked", true, { shouldValidate: true });
       } else {
         setError("nickname", { message: result.message, type: "manual" });
-        setIsNicknameChecked(false);
+        setValue("isNicknameChecked", false, { shouldValidate: true });
       }
     });
   };
 
-  const nicknameValue = watch("nickname");
-
   useEffect(() => {
-    setIsNicknameChecked(false);
-  }, [nicknameValue]);
+    setValue("isNicknameChecked", false);
+  }, [nicknameValue, setValue]);
+
+  let inputValid: undefined | boolean;
+  if (errors.nickname || errors.isNicknameChecked) {
+    inputValid = false;
+  } else if (isNicknameChecked) {
+    inputValid = true;
+  }
+
+  const errorMessage =
+    errors.nickname?.message || errors.isNicknameChecked?.message;
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-body-2 text-text-primary">닉네임</div>
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>닉네임</span>
+        <span className="text-system-error">*</span>
+      </div>
       <div className="flex gap-3">
         <Input
           className="h-[48px] w-[356px]"
@@ -53,8 +67,8 @@ const NicknameSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
           validMessage={
             isNicknameChecked ? "사용 가능한 닉네임입니다." : undefined
           }
-          isValid={errors.nickname ? false : undefined}
-          errorMessage={errors.nickname?.message}
+          errorMessage={errorMessage}
+          isValid={inputValid}
         />
         <Button
           onClick={handleCheckNickname}

--- a/src/components/feature/register/PasswordSection.tsx
+++ b/src/components/feature/register/PasswordSection.tsx
@@ -10,9 +10,12 @@ const PasswordSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
   } = form;
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="text-body-2 text-text-primary">비밀번호</div>
-      <div className="flex flex-col gap-7">
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+          <span>비밀번호</span>
+          <span className="text-system-error">*</span>
+        </div>
         <Input
           className="h-[48px] w-full"
           placeholder="비밀번호를 입력해주세요."
@@ -21,6 +24,12 @@ const PasswordSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
           isValid={errors.password ? false : undefined}
           errorMessage={errors.password?.message}
         />
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+          <span>비밀번호 확인</span>
+          <span className="text-system-error">*</span>
+        </div>
         <Input
           placeholder="비밀번호를 다시 입력해주세요."
           className="h-[48px] w-full"

--- a/src/components/feature/register/PhoneSection.tsx
+++ b/src/components/feature/register/PhoneSection.tsx
@@ -1,0 +1,45 @@
+import { RegisterSchema } from "@app/login/@modal/(.)register/schema";
+import { UseFormReturn, Controller } from "react-hook-form";
+import PhoneInput from "@components/ui/input/PhoneInput";
+
+const PhoneSection = ({ form }: { form: UseFormReturn<RegisterSchema> }) => {
+  const {
+    formState: { errors },
+    control,
+  } = form;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-body-2 flex items-center gap-[2px] text-text-primary">
+        <span>휴대전화</span>
+        <span className="text-system-error">*</span>
+      </div>
+      <div className="flex gap-3">
+        <Controller
+          render={({ field }) => (
+            <PhoneInput
+              values={
+                field.value
+                  ? ([
+                      field.value.slice(0, 3),
+                      field.value.slice(3, 7),
+                      field.value.slice(7, 11),
+                    ] as [string, string, string])
+                  : ["", "", ""]
+              }
+              onChange={(newValues) => {
+                const joinedValue = newValues.join("");
+                field.onChange(joinedValue);
+              }}
+              isValid={errors.phoneNumber ? false : undefined}
+              errorMessage={errors.phoneNumber?.message}
+            />
+          )}
+          name="phoneNumber"
+          control={control}
+        />
+      </div>
+    </div>
+  );
+};
+export default PhoneSection;

--- a/src/components/ui/input/PhoneInput.tsx
+++ b/src/components/ui/input/PhoneInput.tsx
@@ -1,6 +1,6 @@
 import { ValidationMessage } from "@components/ui/input/ValidationMessage";
-import React, { useEffect, useState, useRef } from "react";
 import Input from "@components/ui/input/Input";
+import React, { useRef } from "react";
 
 export type PhoneInputProps = {
   onChange: (value: string[]) => void;
@@ -49,12 +49,6 @@ const PhoneInput = ({
   isValid,
   values,
 }: PhoneInputProps) => {
-  const [phoneValues, setPhoneValues] = useState(values);
-
-  useEffect(() => {
-    onChange(phoneValues);
-  }, [onChange, phoneValues]);
-
   const inputRefs = useRef<Array<HTMLInputElement | null>>([]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -62,16 +56,14 @@ const PhoneInput = ({
     const index = parseInt(name, 10);
     const numericValue = value.replace(/\D/g, "");
 
-    setPhoneValues((prevValues) => {
-      const newValues = [...prevValues];
-      newValues[index] = numericValue;
-      return newValues as [string, string, string];
-    });
+    const newValues = [...values] as [string, string, string];
+    newValues[index] = numericValue;
+    onChange(newValues);
 
     // 자동 포커스 이동 로직
     const maxLength =
       index === 0 ? FIRST_INPUT_MAX_LENGTH : OTHER_INPUT_MAX_LENGTH;
-    const isLastIndex = index >= phoneValues.length - 1;
+    const isLastIndex = index >= values.length - 1;
     const moveFocus = numericValue.length === maxLength && !isLastIndex;
 
     if (moveFocus) {
@@ -82,7 +74,7 @@ const PhoneInput = ({
   return (
     <div className="relative">
       <div className="flex items-center">
-        {phoneValues.map((val, index) => (
+        {values.map((val, index) => (
           <React.Fragment key={index}>
             <Input
               maxLength={
@@ -98,9 +90,7 @@ const PhoneInput = ({
               isValid={isValid}
               value={val}
             />
-            {index < phoneValues.length - 1 && (
-              <span className="px-0.5">-</span>
-            )}
+            {index < values.length - 1 && <span className="px-0.5">-</span>}
           </React.Fragment>
         ))}
       </div>


### PR DESCRIPTION
## 📝작업 내용

> 회원가입폼 누락된부분 마무리
- `POST /users/signup` API 요청/응답 타입 정의를 수정하여 API 연동을 완료했습니다.
- 전화번호 인증번호 요청, 확인, 시간 초과 처리 등 전체 인증 플로우를 구현했습니다.
- 이메일 및 닉네임 중복 확인 로직을 개선하고, 서버 유효성 검사 결과를 UI에 반영하여 사용자 경험을 향상했습니다.
- `react-hook-form`과 서버 액션을 사용하여 폼 상태 관리 및 비동기 로직 처리 구조를 개선했습니다.

