### PR TITLE
feat: 이메일 로그인 api 연동(SCENTLY-111)

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,10 +1,10 @@
 import { API_BASE_URL, URLS } from "@constants/urls";
+import { TOKEN_COOKIE_NAME } from "@constants/auth";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import ky from "ky";
 
 const isServer = typeof window === "undefined";
-const TOKEN_COOKIE_NAME = "jwt_token";
 
 // 인증이 필요 없는 요청을 위한 인스턴스
 export const publicApi = ky.create({
@@ -20,12 +20,12 @@ export const api = publicApi.extend({
 
         if (isServer) {
           const cookieStore = await cookies();
-          token = cookieStore.get(TOKEN_COOKIE_NAME)?.value;
+          token = cookieStore.get(TOKEN_COOKIE_NAME.ACCESS_TOKEN)?.value;
         } else {
           token = document.cookie
             .split("; ")
-            .find((row) => row.startsWith(`${TOKEN_COOKIE_NAME}=`))
-            ?.substring(TOKEN_COOKIE_NAME.length + 1);
+            .find((row) => row.startsWith(`${TOKEN_COOKIE_NAME.ACCESS_TOKEN}=`))
+            ?.substring(TOKEN_COOKIE_NAME.ACCESS_TOKEN.length + 1);
         }
 
         if (token) {

--- a/src/api/login/emailLogin.ts
+++ b/src/api/login/emailLogin.ts
@@ -1,0 +1,27 @@
+import { API_URLS } from "@constants/urls";
+import { publicApi } from "@api/api";
+
+type EmailLoginResponse = {
+  refresh_token: string;
+  access_token: string;
+};
+
+type EmailLoginProps = {
+  password: string;
+  email: string;
+};
+
+const emailLogin = async ({ password, email }: EmailLoginProps) => {
+  const data = await publicApi
+    .post(API_URLS.EMAIL_LOGIN, {
+      json: {
+        password,
+        email,
+      },
+    })
+    .json<EmailLoginResponse>();
+
+  return data;
+};
+
+export default emailLogin;

--- a/src/api/signup/checkEmailVerificationCode.ts
+++ b/src/api/signup/checkEmailVerificationCode.ts
@@ -10,7 +10,7 @@ const checkEmailVerificationCode = async ({
   email,
   code,
 }: CheckEmailVerificationCodeProps) => {
-  const response = await publicApi
+  const data = await publicApi
     .post(`${API_URLS.SIGN_UP_EMAIL_VERIFY}`, {
       json: {
         verification_code: code,
@@ -19,7 +19,7 @@ const checkEmailVerificationCode = async ({
     })
     .json();
 
-  return response;
+  return data;
 };
 
 export default checkEmailVerificationCode;

--- a/src/api/signup/checkNickname.ts
+++ b/src/api/signup/checkNickname.ts
@@ -6,13 +6,13 @@ type CheckNicknameProps = {
 };
 
 const checkNickname = async ({ nickname }: CheckNicknameProps) => {
-  const response = await publicApi
+  const data = await publicApi
     .post(`${API_URLS.SIGN_UP_NICKNAME_CHECK}`, {
       json: { nickname },
     })
     .json();
 
-  return response;
+  return data;
 };
 
 export default checkNickname;

--- a/src/api/signup/sendEmailVerificationCode.ts
+++ b/src/api/signup/sendEmailVerificationCode.ts
@@ -8,13 +8,13 @@ type SendEmailVerificationCodeProps = {
 const sendEmailVerificationCode = async ({
   email,
 }: SendEmailVerificationCodeProps) => {
-  const response = await publicApi
+  const data = await publicApi
     .post(`${API_URLS.SIGN_UP_EMAIL_SEND_CODE}`, {
       json: { email },
     })
     .json();
 
-  return response;
+  return data;
 };
 
 export default sendEmailVerificationCode;

--- a/src/api/signup/signup.ts
+++ b/src/api/signup/signup.ts
@@ -1,44 +1,35 @@
 import { API_URLS } from "@constants/urls";
 import { publicApi } from "@api/api";
 
-type SignupProps = {
+export type SignupData = {
+  gender: "FEMALE" | "MALE";
   password_confirm: string;
   phone_number: string;
   birth_date: string;
   password: string;
   nickname: string;
-  gender: string;
   email: string;
   name: string;
 };
+type SignupProps = {
+  signupData: SignupData;
+};
 
-const signup = async ({
-  password_confirm,
-  phone_number,
-  birth_date,
-  password,
-  nickname,
-  gender,
-  email,
-  name,
-}: SignupProps) => {
+const signup = async ({ signupData }: SignupProps) => {
   const formData = new FormData();
-  formData.append("password_confirm", password_confirm);
-  formData.append("phone_number", phone_number);
-  formData.append("birth_date", birth_date);
-  formData.append("password", password);
-  formData.append("nickname", nickname);
-  formData.append("gender", gender);
-  formData.append("email", email);
-  formData.append("name", name);
+  Object.entries(signupData).forEach(([key, value]) => {
+    if (value) {
+      formData.append(key, value);
+    }
+  });
 
-  const response = await publicApi
+  const data = await publicApi
     .post(`${API_URLS.SIGN_UP}`, {
       body: formData,
     })
     .json();
 
-  return response;
+  return data;
 };
 
 export default signup;

--- a/src/app/login/@modal/(.)register/actions.ts
+++ b/src/app/login/@modal/(.)register/actions.ts
@@ -18,20 +18,12 @@ export async function register(
   prevState: FormState,
   formData: FormData,
 ): Promise<FormState> {
-  const data = {
-    isNicknameChecked: formData.get("isNicknameChecked") === "true",
-    verificationCode: formData.get("verificationCode") as string,
-    isEmailVerified: formData.get("isEmailVerified") === "true",
-    passwordConfirm: formData.get("passwordConfirm") as string,
-    phoneNumber: formData.get("phoneNumber") as string,
-    birthDate: formData.get("birthDate") as string,
-    nickname: formData.get("nickname") as string,
-    password: formData.get("password") as string,
-    gender: formData.get("gender") as string,
-    email: formData.get("email") as string,
-    name: formData.get("name") as string,
-  };
-  const validatedFields = registerSchema.safeParse(data);
+  const data = Object.fromEntries(formData);
+  const validatedFields = registerSchema.safeParse({
+    ...data,
+    isNicknameChecked: data.isNicknameChecked === "true",
+    isEmailVerified: data.isEmailVerified === "true",
+  });
 
   if (!validatedFields.success) {
     return {
@@ -44,14 +36,12 @@ export async function register(
 
   try {
     await signupApi({
-      password_confirm: validatedFields.data.passwordConfirm,
-      phone_number: validatedFields.data.phoneNumber,
-      birth_date: validatedFields.data.birthDate,
-      password: validatedFields.data.password,
-      nickname: validatedFields.data.nickname,
-      gender: validatedFields.data.gender,
-      email: validatedFields.data.email,
-      name: validatedFields.data.name,
+      signupData: {
+        ...validatedFields.data,
+        password_confirm: validatedFields.data.passwordConfirm,
+        phone_number: validatedFields.data.phoneNumber,
+        birth_date: validatedFields.data.birthDate,
+      },
     });
 
     return { message: "회원가입이 정상적으로 완료되었습니다.", success: true };

--- a/src/app/login/@modal/(.)register/actions.ts
+++ b/src/app/login/@modal/(.)register/actions.ts
@@ -35,12 +35,14 @@ export async function register(
   }
 
   try {
+    const { passwordConfirm, phoneNumber, birthDate, ...rest } =
+      validatedFields.data;
     await signupApi({
       signupData: {
-        ...validatedFields.data,
-        password_confirm: validatedFields.data.passwordConfirm,
-        phone_number: validatedFields.data.phoneNumber,
-        birth_date: validatedFields.data.birthDate,
+        ...rest,
+        password_confirm: passwordConfirm,
+        phone_number: phoneNumber,
+        birth_date: birthDate,
       },
     });
 

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -15,6 +15,9 @@ export type EmailLoginFormState = {
   message: string;
 };
 
+// TODO: 환경변수 추가 필요
+const isProduction = process.env.NODE_ENV === "production";
+
 export async function emailLogin(
   prevState: EmailLoginFormState,
   formData: FormData,
@@ -49,8 +52,18 @@ export async function emailLogin(
   }
 
   const cookieStore = await cookies();
-  cookieStore.set(TOKEN_COOKIE_NAME.ACCESS_TOKEN, apiResult.access_token);
-  cookieStore.set(TOKEN_COOKIE_NAME.REFRESH_TOKEN, apiResult.refresh_token);
+  cookieStore.set(TOKEN_COOKIE_NAME.ACCESS_TOKEN, apiResult.access_token, {
+    secure: isProduction,
+    sameSite: "lax",
+    httpOnly: true,
+    path: "/",
+  });
+  cookieStore.set(TOKEN_COOKIE_NAME.REFRESH_TOKEN, apiResult.refresh_token, {
+    secure: isProduction,
+    sameSite: "lax",
+    httpOnly: true,
+    path: "/",
+  });
 
   redirect(URLS.HOME);
 }

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { emailLoginSchema, EmailLoginSchema } from "@app/login/schema";
+import { TOKEN_COOKIE_NAME } from "@constants/auth";
+import emailLoginApi from "@api/login/emailLogin";
+import { redirect } from "next/navigation";
+import { cookies } from "next/headers";
+import { URLS } from "@constants/urls";
+import { HTTPError } from "ky";
+import { z } from "zod";
+
+export type EmailLoginFormState = {
+  errors?: Record<keyof EmailLoginSchema, undefined | string[]>;
+  success: boolean;
+  message: string;
+};
+
+export async function emailLogin(
+  prevState: EmailLoginFormState,
+  formData: FormData,
+): Promise<EmailLoginFormState> {
+  const data = Object.fromEntries(formData);
+  const validatedFields = emailLoginSchema.safeParse(data);
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error)
+        .fieldErrors as EmailLoginFormState["errors"],
+      message: "입력 내용을 다시 확인해주세요.",
+      success: false,
+    };
+  }
+
+  let apiResult;
+  try {
+    apiResult = await emailLoginApi({
+      password: validatedFields.data.password,
+      email: validatedFields.data.email,
+    });
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      const errorResponse = await error.response.json();
+      const errorMessage =
+        errorResponse.detail || "아이디 또는 비밀번호가 일치하지 않습니다.";
+
+      return { message: errorMessage, success: false };
+    }
+    return { message: "알 수 없는 에러가 발생했습니다.", success: false };
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(TOKEN_COOKIE_NAME.ACCESS_TOKEN, apiResult.access_token);
+  cookieStore.set(TOKEN_COOKIE_NAME.REFRESH_TOKEN, apiResult.refresh_token);
+
+  redirect(URLS.HOME);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -41,6 +41,8 @@ export default function LoginPage() {
   });
 
   useEffect(() => {
+    if (state.success) return;
+
     if (state.errors) {
       Object.entries(state.errors).forEach(([key, value]) => {
         if (value) {
@@ -48,10 +50,11 @@ export default function LoginPage() {
             message: value[0],
             type: "server",
           });
-        } else if (!state.success && state.message) {
-          alert(state.message);
         }
       });
+    } else if (state.message) {
+      // TODO: alert 대신 UI에 에러 메시지를 표시하도록 개선
+      alert(state.message);
     }
   }, [state, setError]);
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,43 +1,99 @@
 "use client";
 
+import { EmailLoginSchema, emailLoginSchema } from "@app/login/schema";
+import { useActionState, useTransition, useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { emailLogin } from "@app/login/actions";
 import Input from "@components/ui/input/Input";
 import Logo from "@assets/logo/logo-gray.svg";
-import { useRouter } from "next/navigation";
 import Button from "@components/ui/Button";
+import { useForm } from "react-hook-form";
+import { URLS } from "@constants/urls";
+import Link from "next/link";
 
 export default function LoginPage() {
-  const router = useRouter();
+  const [state, formAction] = useActionState(emailLogin, {
+    success: false,
+    message: "",
+  });
+  const [isPending, startTransition] = useTransition();
+
+  const {
+    formState: { errors },
+    handleSubmit,
+    register,
+    setError,
+  } = useForm<EmailLoginSchema>({
+    defaultValues: {
+      password: "",
+      email: "",
+    },
+    resolver: zodResolver(emailLoginSchema),
+    mode: "onChange",
+  });
+
+  const onSubmit = handleSubmit(async (data) => {
+    const formData = new FormData();
+    Object.entries(data).forEach(([key, value]) => {
+      formData.append(key, value.toString());
+    });
+    startTransition(() => formAction(formData));
+  });
+
+  useEffect(() => {
+    if (state.errors) {
+      Object.entries(state.errors).forEach(([key, value]) => {
+        if (value) {
+          setError(key as keyof EmailLoginSchema, {
+            message: value[0],
+            type: "server",
+          });
+        } else if (!state.success && state.message) {
+          alert(state.message);
+        }
+      });
+    }
+  }, [state, setError]);
+
   return (
     <div className="bg-background-default flex h-screen w-full flex-col items-center gap-8">
       <div className="mt-[224px] flex w-[328px] flex-col items-center gap-10">
         <Logo aria-label="logo" />
         <div className="text-button-1 flex gap-3 px-10 text-text-secondary">
           <div>아직 회원이 아니신가요?</div>
-          <button
-            onClick={() => router.push("/login/register", { scroll: false })}
+          <Link
             className="cursor-pointer text-text-primary"
+            href={URLS.REGISTER_MODAL}
+            scroll={false}
           >
             회원가입 하기
-          </button>
+          </Link>
         </div>
       </div>
-      <form className="flex w-[328px] flex-col gap-4">
-        <div className="flex flex-col gap-3">
+      <form className="flex w-[328px] flex-col gap-6" onSubmit={onSubmit}>
+        <div className="flex flex-col gap-6">
+          {/* TODO: 에러 메시지 표현 케이스 체크 */}
           <Input
             placeholder="아이디 (example@gmail.com)"
             className="w-full"
             aria-label="아이디"
             type="email"
+            {...register("email")}
+            isValid={errors.email ? false : undefined}
+            errorMessage={errors.email?.message}
           />
           <Input
             className="w-full"
             placeholder="비밀번호"
             aria-label="비밀번호"
             type="password"
+            {...register("password")}
+            isValid={errors.password ? false : undefined}
+            errorMessage={errors.password?.message}
           />
         </div>
-        <Button aria-label="일반회원 로그인" type="submit" size={"2xl"}>
-          일반회원 로그인
+        <Button disabled={isPending} type="submit" size={"2xl"}>
+          {isPending ? "로그인 중..." : "일반회원 로그인"}
         </Button>
       </form>
     </div>

--- a/src/app/login/schema.ts
+++ b/src/app/login/schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const emailLoginSchema = z.object({
+  password: z.string().min(1, "비밀번호를 입력해주세요."),
+  email: z.email("올바른 이메일 형식이 아닙니다."),
+});
+
+export type EmailLoginSchema = z.infer<typeof emailLoginSchema>;

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,4 @@
+export const TOKEN_COOKIE_NAME = {
+  REFRESH_TOKEN: "refresh_token",
+  ACCESS_TOKEN: "access_token",
+};

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,4 +1,5 @@
 export const URLS = {
+  REGISTER_MODAL: "/login/register",
   MY_PAGE_MODAL: "/my-page-modal",
   AI_SEARCH: "/ai-search",
   PROMOTION: "/promotion",
@@ -15,6 +16,7 @@ export const API_URLS = {
   SIGN_UP_EMAIL_SEND_CODE: "/auth/signup/email/send-code/",
   SIGN_UP_NICKNAME_CHECK: "/auth/signup/nickname-check/",
   SIGN_UP_EMAIL_VERIFY: "/auth/signup/email/verify/",
+  EMAIL_LOGIN: "/auth/login/email/",
   SIGN_UP: "/auth/signup/",
 };
 


### PR DESCRIPTION
## 📝작업 내용

> 이메일 로그인 api 연동
- token 상수 액세스토큰, 리프레시토큰 분리
- api 함수들이 .json 실행한 데이터를 성공시 반환하도록 수정(통일)
- formData 사용할때 값 추가하는 코드를 더 간결하게 수정
- 로그인페이지 회원가입 모달 여는 부분을 Link로 수정

테스트가 필요한데 문제 생기면 서버 고쳐진 이후에 코드 수정하면서 같이 수정하겠습니다

